### PR TITLE
Add .gitattributes to shrink installs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/test export-ignore
+/phpunit.xml export-ignore
+/.github export-ignore
+/.circleci export-ignore
+/.codeclimate.yml export-ignore


### PR DESCRIPTION
#### Why?
By ignoring the tests and build information, people who install the library (typically via composer) will have fewer files to deal with that they don't need to use the library. People developing against it will still have access to them via a normal checkout.

#### How?
Add a `.gitattributes` file to exclude certain paths from export.
